### PR TITLE
pr treat node and edge separate in network table and node_search zod requirements update

### DIFF
--- a/app/api/knowledge_graph/node_search/route.ts
+++ b/app/api/knowledge_graph/node_search/route.ts
@@ -10,7 +10,7 @@ import { convert_query } from "@/utils/helper"
 const query_schema = z.object({
     type: z.string(),
     field: z.optional(z.string()),
-    term: z.optional(z.string()),
+    term: z.optional(z.union([z.string(), z.number(), z.nan()])), 
     limit: z.optional(z.number()),
     filter: z.optional(zu.stringToJSON())
 })

--- a/components/TermAndGeneSearch/network_table.tsx
+++ b/components/TermAndGeneSearch/network_table.tsx
@@ -42,7 +42,7 @@ const NetworkTable = ({data, schema}: {data: NetworkSchema, schema: UISchema}) =
 			// Process nodes first
 			for (const d of data.nodes) {
 				const properties = d.data
-				const {kind, relation, source, target, label, "Unnamed: 0": _, ...rest} = d.data
+				const {kind, relation, source, target, label, ...rest} = d.data
 				const key = `node_${kind}`
 				
 				if (kind && typeof kind === 'string') {
@@ -139,7 +139,7 @@ const NetworkTable = ({data, schema}: {data: NetworkSchema, schema: UISchema}) =
 			// Process edges
 			for (const d of data.edges) {
 				const properties = d.data
-				const {kind, relation, source, target, label, "Unnamed: 0": _, ...rest} = d.data
+				const {kind, relation, source, target, label, ...rest} = d.data
 				if (properties.id === undefined) properties.id = `${source}_${target}`
 				const key = `edge_${relation}`
 				
@@ -255,6 +255,9 @@ const NetworkTable = ({data, schema}: {data: NetworkSchema, schema: UISchema}) =
 								scrollButtons="auto"
 								onChange={(e, val)=>setTab(val)}
 								aria-label="tab"
+								sx={{
+									'& .MuiTab-root.Mui-selected': {color: '#336699',}
+								}}
 							>
 							{tabs.map(k=>(
 								<Tab value={k} aria-label="left aligned" key={`tab-${k}`} label={k.replace('node_', '').replace('edge_', '') + (k.startsWith('node_') ? ' nodes' : ' edges')}/>

--- a/components/TermAndGeneSearch/network_table.tsx
+++ b/components/TermAndGeneSearch/network_table.tsx
@@ -7,6 +7,7 @@ import { DataGrid, GridToolbar, GridColDef } from "@mui/x-data-grid";
 import { UISchema } from "@/app/api/schema/route";
 import { NetworkSchema } from "@/app/api/knowledge_graph/route";
 import { CustomToolbar } from "../Enrichment/NetworkTable";
+
 const NetworkTable = ({data, schema}: {data: NetworkSchema, schema: UISchema}) => {
 	const [processedData, setProcessedData] = useState<{
 		[key:string]: {
@@ -15,40 +16,44 @@ const NetworkTable = ({data, schema}: {data: NetworkSchema, schema: UISchema}) =
 			columnVisibilityModel: {[key: string]: boolean}
 		}
 	} | null>(null)
-	// const [mapper, setMapper] = useState({})
 	const tableRef = useRef(null)
 	const [tab, setTab] = useState<null | string>(null)
 	const [tabs, setTabs] = useState<Array<string>>(null)
-	const display = {}
+	
+	// Separate display configs for nodes and edges
+	const nodeDisplay = {}
+	const edgeDisplay = {}
+	
 	for (const i of schema.nodes) {
-		display[i.node] = i.display
+		nodeDisplay[i.node] = i.display
 	}
 	for (const i of schema.edges) {
 		for (const m of i.match) {
-			display[m] = i.display
+			edgeDisplay[m] = i.display
 		}
 	}
 
 	useEffect(()=>{
 		if (data) {
 			const processed = {}
-			const id_mapper = {}
 			const node_tabs = []
 			const edge_tabs = []
-			for (const d of [...data.nodes, ...data.edges]) {
+			
+			// Process nodes first
+			for (const d of data.nodes) {
 				const properties = d.data
 				const {kind, relation, source, target, label, "Unnamed: 0": _, ...rest} = d.data
-				if (properties.id === undefined) properties.id = `${source}_${target}`
-				const key = relation || kind
-				if (key && typeof key === 'string') { 
-					if ( processed[key] === undefined) {
-						if (relation) edge_tabs.push(key)
-						else node_tabs.push(key)
+				const key = `node_${kind}`
+				
+				if (kind && typeof kind === 'string') {
+					if (processed[key] === undefined) {
+						node_tabs.push(key)
 						processed[key] = {header: [], data: {}, columnVisibilityModel: {}}
 						const header = []
 						const columnVisibilityModel = {}
-						if (display[key]) {
-							for (const prop of display[key]) {
+						
+						if (nodeDisplay[kind]) {
+							for (const prop of nodeDisplay[kind]) {
 								const field = prop.label
 								columnVisibilityModel[field] = !(prop.hide)
 								if (prop.type === "link") {
@@ -65,7 +70,6 @@ const NetworkTable = ({data, schema}: {data: NetworkSchema, schema: UISchema}) =
 										},
 										count: 0
 									})
-
 								} else {
 									header.push({
 										field,
@@ -78,34 +82,23 @@ const NetworkTable = ({data, schema}: {data: NetworkSchema, schema: UISchema}) =
 									})
 								}
 							}
-						} else if (typeof properties.id === 'string') {
-							const {id, symbol, ref, ...rest} = properties
-							id_mapper[id] = label
-							// header.push({
-							// 	field: 'id',
-							// 	headerName: "ID",
-							// 	flex: 1,
-							// 	style: {flexDirection: "row"},
-							// 	align: "left",
-							// 	type: relation ? "edge": "node",
-							// })
+						} else {
 							header.push({
 								field: 'label',
 								headerName: "Label",
 								flex: 1,
 								style: {flexDirection: "row"},
 								align: "left",
-								type: relation ? "edge": "node",
+								type: "node",
 							})
 							for (const field of Object.keys(rest)) {
 								const headerName = field.replaceAll(".", " ")
 								header.push({
 									field,
 									headerName: headerName.charAt(0).toUpperCase() + headerName.slice(1),
-									// flex: 1,
 									style: {flexDirection: "row"},
 									align: "left",
-									type: relation ? "edge": "node",
+									type: "node",
 									count: 0
 								})
 							}
@@ -113,6 +106,8 @@ const NetworkTable = ({data, schema}: {data: NetworkSchema, schema: UISchema}) =
 						processed[key].header = header
 						processed[key].columnVisibilityModel = columnVisibilityModel
 					}
+					
+					// Process node data
 					if (processed[key].data[properties.id] === undefined) {
 						processed[key].data[properties.id] = {id: properties.id}
 					}
@@ -135,15 +130,116 @@ const NetworkTable = ({data, schema}: {data: NetworkSchema, schema: UISchema}) =
 							}
 						}
 					}
-					if (processed[key].data[properties.id]["label"] === "") processed[key].data[properties.id]["label"] = label
-				} 
+					if (processed[key].data[properties.id]["label"] === "") {
+						processed[key].data[properties.id]["label"] = label
+					}
+				}
 			}
-			// setMapper(id_mapper)
+			
+			// Process edges
+			for (const d of data.edges) {
+				const properties = d.data
+				const {kind, relation, source, target, label, "Unnamed: 0": _, ...rest} = d.data
+				if (properties.id === undefined) properties.id = `${source}_${target}`
+				const key = `edge_${relation}`
+				
+				if (relation && typeof relation === 'string') {
+					if (processed[key] === undefined) {
+						edge_tabs.push(key)
+						processed[key] = {header: [], data: {}, columnVisibilityModel: {}}
+						const header = []
+						const columnVisibilityModel = {}
+						
+						if (edgeDisplay[relation]) {
+							for (const prop of edgeDisplay[relation]) {
+								const field = prop.label
+								columnVisibilityModel[field] = !(prop.hide)
+								if (prop.type === "link") {
+									header.push({
+										field,
+										headerName: field,
+										flex: 1,
+										style: {flexDirection: "row"},
+										align: "left",
+										text: prop.text,
+										href: prop.href,
+										renderCell: ({row, field})=>{
+											return <Button href={row[field].href}>{row[field].text}</Button>
+										},
+										count: 0
+									})
+								} else {
+									header.push({
+										field,
+										headerName: field,
+										flex: 1,
+										style: {flexDirection: "row"},
+										align: "left",
+										text: prop.text,
+										count: 0
+									})
+								}
+							}
+						} else {
+							header.push({
+								field: 'label',
+								headerName: "Label",
+								flex: 1,
+								style: {flexDirection: "row"},
+								align: "left",
+								type: "edge",
+							})
+							for (const field of Object.keys(rest)) {
+								const headerName = field.replaceAll(".", " ")
+								header.push({
+									field,
+									headerName: headerName.charAt(0).toUpperCase() + headerName.slice(1),
+									style: {flexDirection: "row"},
+									align: "left",
+									type: "edge",
+									count: 0
+								})
+							}
+						}
+						processed[key].header = header
+						processed[key].columnVisibilityModel = columnVisibilityModel
+					}
+					
+					// Process edge data
+					if (processed[key].data[properties.id] === undefined) {
+						processed[key].data[properties.id] = {id: properties.id}
+					}
+					for (const i of processed[key].header) {
+						if (i.href) {
+							const val = makeTemplate(i.text, properties)
+							const href = makeTemplate(i.href, properties)
+							processed[key].data[properties.id][i.field] = {
+								text: val === "undefined" ? "": val,
+								href: href === "undefined" ? "": href
+							}
+							if (val !== "undefined") {
+								i.count = i.count + 1
+							}
+						} else {
+							const val = makeTemplate(i.text, properties)
+							processed[key].data[properties.id][i.field] = val === "undefined" ? "": precise(val)
+							if (val !== "undefined") {
+								i.count = i.count + 1
+							}
+						}
+					}
+					if (processed[key].data[properties.id]["label"] === "") {
+						processed[key].data[properties.id]["label"] = label
+					}
+				}
+			}
+			
 			setTabs([...node_tabs, ...edge_tabs])
 			setTab(node_tabs[0])
 			setProcessedData(processed)	
 		}
 	}, [data])
+
 	if (processedData === null) return null
 	else {
 		const {data={}, header=[], columnVisibilityModel} = processedData[tab] || {}
@@ -161,7 +257,7 @@ const NetworkTable = ({data, schema}: {data: NetworkSchema, schema: UISchema}) =
 								aria-label="tab"
 							>
 							{tabs.map(k=>(
-								<Tab value={k} aria-label="left aligned" key={`tab-${k}`} label={k}/>
+								<Tab value={k} aria-label="left aligned" key={`tab-${k}`} label={k.replace('node_', '').replace('edge_', '') + (k.startsWith('node_') ? ' nodes' : ' edges')}/>
 							))}
 							</Tabs>
 						</Grid>


### PR DESCRIPTION
There are two main changes I made to support the co-authorship network:

1. I changed around NetworkTable.tsx in the TermAndGeneSearch component so that it treats edge and node tabs as separate (in the case of same node name and edge name). 

2. Additionally, before the node search would be no_results if there was a number even if the input was a number, so I changed around the requirements for that search in zod.